### PR TITLE
Show run-level trial counts after test filtering

### DIFF
--- a/mvpa_mem_react/main_scripts/mvpa_MR.m
+++ b/mvpa_mem_react/main_scripts/mvpa_MR.m
@@ -213,6 +213,7 @@ for i = 1:size(xclass_specs,1)
         test_mask_all = test_mask_all & keep_test;
     end
     print_cond_counts(conditions, test_mask_all, sprintf('Test set %s after filters', tag));
+    print_run_cond_counts(conditions, runs, test_mask_all, sprintf('Test per run after filters %s', tag));
     if ~any(test_mask_all)
         error('mvpa_MR:noTestTrials', ...
             'No test trials remain for %s (%s) in runs %s after filtering', ...


### PR DESCRIPTION
## Summary
- print trials per run after applying filters to each test set

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882321949c88326914cb6b04502841c