### PR TITLE
Add p-values via decoding_statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ provides a reproducible pipeline for each subject.
 - Cross‑classification on additional label/run splits.
 - Outputs confusion matrices, PNG visualisations and a summary CSV with several
   performance metrics.
+- Computes binomial p-values via TDT's `decoding_statistics`.
 
 ## Usage
 ```


### PR DESCRIPTION
## Summary
- compute binomial p-values using TDT's `decoding_statistics` in `mvpa_MR`
- store per-run p-values
- document new behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889c6a1987483268ce635ec4ba98f2c