### PR TITLE
Fix cross-class p-value computation

### DIFF
--- a/mvpa_mem_react/main_scripts/mvpa_MR.m
+++ b/mvpa_mem_react/main_scripts/mvpa_MR.m
@@ -443,7 +443,11 @@ for i = 1:numel(fn)
     MCC(end+1,1)            = m.mcc;
     Kappa(end+1,1)          = m.kappa;
     AUCminusChance(end+1,1) = xclass_out.(tag).auc_mean;
-    AccPValue(end+1,1)      = xclass_out.(tag).acc_p;
+    % Use the mean of per-run p-values rather than the aggregate binomial
+    % statistic computed from the summed confusion matrix. This better
+    % reflects the average significance across runs.
+    pvals = cell2mat(xclass_out.(tag).p_list);
+    AccPValue(end+1,1)      = mean(pvals, 'omitnan');
 end
 
 tbl = table(RowID,Type,Tag,AccMinusChance_TDT,BalancedAcc,Sensitivity,Specificity,MCC,Kappa,AUCminusChance,AccPValue, ...


### PR DESCRIPTION
## Summary
- compute xclass p-value as the mean of per-run p-values rather than the aggregate binomial test

## Testing
- `matlab`/`octave` not available, so no tests executed

------
https://chatgpt.com/codex/tasks/task_e_6889d2f4c48083268e7a2279fafa622e