### PR TITLE
Improve final metrics table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ provides a reproducible pipeline for each subject.
 - Outputs confusion matrices, PNG visualisations and a summary CSV with several
   performance metrics.
 - Also writes `summary_final.csv`, a single-row table containing every metric
-  computed for that subject (per run and averaged).
+  computed for that subject. Metrics are grouped by type with mean values
+  listed before the per-run results.
 - Computes binomial p-values via TDT's `decoding_statistics`.
 
 ## Usage


### PR DESCRIPTION
## Summary
- reorder the final summary table so means come first and values are grouped by metric
- document layout of `summary_final.csv`

## Testing
- `apt-get update`
- `apt-get install -y octave` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_6889da3dea8c832684a3e7dc686dd074