### PR TITLE
Move Subject column first

### DIFF
--- a/mvpa_mem_react/main_scripts/mvpa_MR_batch_example.m
+++ b/mvpa_mem_react/main_scripts/mvpa_MR_batch_example.m
@@ -61,6 +61,8 @@ for i = 1:numel(mat_files)
         % Append the final table for this subject to the group table
         final_tbl = res.final;
         final_tbl.Subject = string(sub_name);
+        % Place the Subject column first in the table
+        final_tbl = movevars(final_tbl, 'Subject', 'Before', 1);
         group_table = [group_table; final_tbl];
 
          close all


### PR DESCRIPTION
## Summary
- place the `Subject` column at the beginning of the table in the batch example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889eda91d7883269faa955873b3bb58